### PR TITLE
Implemented missing fillZoomRectangle for ChartComposite

### DIFF
--- a/src/main/java/org/jfree/chart/swt/ChartComposite.java
+++ b/src/main/java/org/jfree/chart/swt/ChartComposite.java
@@ -233,7 +233,7 @@ public class ChartComposite extends Composite implements ChartChangeListener,
     private transient Rectangle zoomRectangle = null;
 
     /** Controls if the zoom rectangle is drawn as an outline or filled. */
-    //TODO private boolean fillZoomRectangle = true;
+    private boolean fillZoomRectangle = true;
 
     /** The minimum distance required to drag the mouse to trigger a zoom. */
     private int zoomTriggerDistance;
@@ -641,6 +641,26 @@ public class ChartComposite extends Composite implements ChartChangeListener,
         else {
             this.rangeZoomable = false;
         }
+    }
+
+    /**
+     * Returns the flag that controls whether or not the zoom rectangle is
+     * filled when drawn.
+     *
+     * @return A boolean.
+     */
+    public boolean getFillZoomRectangle() {
+        return this.fillZoomRectangle;
+    }
+
+    /**
+     * A flag that controls how the zoom rectangle is drawn.
+     *
+     * @param flag  {@code true} instructs to fill the rectangle on
+     *              zoom, otherwise it will be outlined.
+     */
+    public void setFillZoomRectangle(boolean flag) {
+        this.fillZoomRectangle = flag;
     }
 
     /**
@@ -1817,7 +1837,13 @@ public class ChartComposite extends Composite implements ChartChangeListener,
         this.verticalTraceLineX = 0;
         this.horizontalTraceLineY = 0;
         if (this.zoomRectangle != null) {
+            e.gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLUE));
             e.gc.drawRectangle(this.zoomRectangle);
+            if(this.fillZoomRectangle) {
+                e.gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_BLUE));
+                e.gc.setAlpha(63);
+                e.gc.fillRectangle(this.zoomRectangle);
+            }
         }
         sg2.dispose();
     }

--- a/src/main/java/org/jfree/chart/swt/ChartComposite.java
+++ b/src/main/java/org/jfree/chart/swt/ChartComposite.java
@@ -235,6 +235,9 @@ public class ChartComposite extends Composite implements ChartChangeListener,
     /** Controls if the zoom rectangle is drawn as an outline or filled. */
     private boolean fillZoomRectangle = true;
 
+    /** Color for the selection rectangle */
+    private org.eclipse.swt.graphics.Color selectionColor = getDisplay().getSystemColor(SWT.COLOR_BLUE);
+
     /** The minimum distance required to drag the mouse to trigger a zoom. */
     private int zoomTriggerDistance;
 
@@ -661,6 +664,24 @@ public class ChartComposite extends Composite implements ChartChangeListener,
      */
     public void setFillZoomRectangle(boolean flag) {
         this.fillZoomRectangle = flag;
+    }
+
+    /**
+     * Returns the color used to draw the zoom rectangle
+     *
+     * @return Current selection color
+     */
+    public org.eclipse.swt.graphics.Color getSelectionColor () {
+        return this.selectionColor;
+    }
+
+    /**
+     * Changes the color used to draw the zoom rectangle
+     *
+     * @param color New selection color
+     */
+    public void setSelectionColor(org.eclipse.swt.graphics.Color color) {
+        this.selectionColor = color;
     }
 
     /**
@@ -1837,10 +1858,10 @@ public class ChartComposite extends Composite implements ChartChangeListener,
         this.verticalTraceLineX = 0;
         this.horizontalTraceLineY = 0;
         if (this.zoomRectangle != null) {
-            e.gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLUE));
+            e.gc.setForeground(this.selectionColor);
             e.gc.drawRectangle(this.zoomRectangle);
             if(this.fillZoomRectangle) {
-                e.gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_BLUE));
+                e.gc.setBackground(this.selectionColor);
                 e.gc.setAlpha(63);
                 e.gc.fillRectangle(this.zoomRectangle);
             }

--- a/src/main/java/org/jfree/chart/swt/demo/SWTTimeSeriesDemo1.java
+++ b/src/main/java/org/jfree/chart/swt/demo/SWTTimeSeriesDemo1.java
@@ -173,6 +173,7 @@ public class SWTTimeSeriesDemo1 {
         shell.setLayout(new FillLayout());
         shell.setText("Time series demo for jfreechart running with SWT");
         ChartComposite frame = new ChartComposite(shell, SWT.NONE, chart, true);
+        frame.setFillZoomRectangle(true);
         frame.setDisplayToolTips(true);
         frame.setHorizontalAxisTrace(false);
         frame.setVerticalAxisTrace(false);

--- a/src/main/java/org/jfree/chart/swt/demo/SWTTimeSeriesDemo1.java
+++ b/src/main/java/org/jfree/chart/swt/demo/SWTTimeSeriesDemo1.java
@@ -173,6 +173,7 @@ public class SWTTimeSeriesDemo1 {
         shell.setLayout(new FillLayout());
         shell.setText("Time series demo for jfreechart running with SWT");
         ChartComposite frame = new ChartComposite(shell, SWT.NONE, chart, true);
+        frame.setSelectionColor(display.getSystemColor(SWT.COLOR_RED));
         frame.setFillZoomRectangle(true);
         frame.setDisplayToolTips(true);
         frame.setHorizontalAxisTrace(false);


### PR DESCRIPTION
The Swing-Component ChartPanel from JFreeChart has an option to fill the zoom rectangle. 

This was still missing in the ChartComposite implementation. Therefore, I added it to make it more similar to the ChartPanel implementation. 

Additionally, I also added a method to change the color of the zoom rectangle.